### PR TITLE
ci: add npm-publish task

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,33 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is published
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_SECRET}}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
 	"version": "0.0.0",
 	"description": "The Solidity implemention of the Merkle trees used in Fuel v2.",
 	"main": "test/index.js",
-	"private": true,
 	"license": "Apache-2.0",
 	"scripts": {
 		"build": "npm run clean && npm run compile",


### PR DESCRIPTION
Resolves https://github.com/FuelLabs/fuel-merkle-sol/issues/5

### For Reviewers
1. Prior to merging, can you please confirm that a `NPM_SECRET` has been added to: https://github.com/FuelLabs/fuel-merkle-sol/settings/secrets/actions ? The token should have type: Automation.

### Questions
1. Do we want to increase the version to `0.1.0` in this PR? If not, I think we can do this prior to the first release https://github.com/FuelLabs/fuel-merkle-sol/blob/da0d0d35f51dd98ffd2232a1f15e87a785fdfca3/package.json#L3
3. Do we want to publish this package to an organization namespace like `@FuelLabs`? If so, we likely want to add a prefix to https://github.com/FuelLabs/fuel-merkle-sol/blob/da0d0d35f51dd98ffd2232a1f15e87a785fdfca3/package.json#L2

### Testing
1. Pushed this to my fork: https://github.com/rootulp/fuel-merkle-sol
4. Successful GH action: https://github.com/rootulp/fuel-merkle-sol/runs/6027859858?check_suite_focus=true
5. Verified package got published to https://www.npmjs.com/package/rootulp-fuel-merkle-sol